### PR TITLE
fix: align Docker CI OpenClaw version with Dockerfile default

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -70,7 +70,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             EVERCLAW_VERSION=${{ steps.version.outputs.VERSION }}
-            OPENCLAW_VERSION=v2026.2.22
+            OPENCLAW_VERSION=v2026.3.11
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Problem

`docker-build.yml` passes `OPENCLAW_VERSION=v2026.2.22` as a build-arg, which overrides the Dockerfile `ARG OPENCLAW_VERSION=v2026.3.11`. This means CI-built images are pinned to a stale OpenClaw release even though the Dockerfile was already updated.

## Fix

One-line change: update the workflow build-arg to `v2026.3.11` to match the Dockerfile default.

Going forward, it might be worth having the workflow read the version from the Dockerfile or a shared variable to prevent future drift.